### PR TITLE
fix: error_message

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module NdcQuiz
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
+    # デフォルトのロケールを日本語に設定
+    config.i18n.default_locale = :ja
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,15 @@
+ja:
+  activerecord:
+    # ここで各モデルの属性の人間らしい名前を指定できます。
+    attributes:
+      user:
+        name: ""
+        password: ""
+    errors:
+      models:
+        user:
+          attributes:
+            name:
+              taken: "ご入力のIDでは登録できませんでした。別のIDをお試しください。"
+            password:
+              too_short: "パスワードは%{count}文字以上で入力してください。"


### PR DESCRIPTION
- [x] エラーメッセージについて、辞書攻撃等されないように曖昧な表現に修正。
- [x] i18n対応。